### PR TITLE
Ensure non leader units set waiting status

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -12,7 +12,7 @@ from urllib.parse import urlparse
 
 from ops.charm import CharmBase
 from ops.main import main
-from ops.model import ActiveStatus, BlockedStatus
+from ops.model import ActiveStatus, BlockedStatus, WaitingStatus
 
 logger = logging.getLogger(__name__)
 
@@ -67,6 +67,7 @@ class PrometheusScrapeTargetCharm(CharmBase):
     def _update_prometheus_jobs(self, _):
         """Setup Prometheus scrape configuration for external targets."""
         if not self.unit.is_leader():
+            self.unit.status = WaitingStatus("inactive unit")
             return
 
         if jobs := self._scrape_jobs():

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -6,7 +6,7 @@
 import json
 import unittest
 
-from ops.model import ActiveStatus, BlockedStatus
+from ops.model import ActiveStatus, BlockedStatus, WaitingStatus
 from ops.testing import Harness
 
 from charm import PrometheusScrapeTargetCharm
@@ -182,3 +182,11 @@ class TestCharm(unittest.TestCase):
 
         self.assertIsInstance(self.harness.model.unit.status, BlockedStatus)
         self.assertEqual({}, dict(relation_data))
+
+    def test_non_leader_unit_sets_waiting_status(self):
+        """Test units that are not leader are marked inactive."""
+        self.harness.set_leader(False)
+
+        self.harness.update_config({"targets": "https://192.186.1.0:1234"})
+
+        self.assertEqual(self.harness.model.unit.status, WaitingStatus("inactive unit"))


### PR DESCRIPTION
Scaling the scrape target charm serves no purpose. Hence this
commit ensures that any unit that is not the leader sets
its status as waiting status with message "inactive unit".