### PR TITLE
FIX #9 - Now we can blank targets

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -69,10 +69,11 @@ class PrometheusScrapeTargetCharm(CharmBase):
         if not self.unit.is_leader():
             return
 
-        if jobs := self._scrape_jobs():
-            for relation in self.model.relations[self._prometheus_relation]:
-                relation.data[self.app]["scrape_jobs"] = json.dumps(jobs)
+        jobs = self._scrape_jobs()
+        for relation in self.model.relations[self._prometheus_relation]:
+            relation.data[self.app]["scrape_jobs"] = json.dumps(jobs)
 
+        if jobs:
             self.unit.status = ActiveStatus()
 
     def _scrape_jobs(self) -> list:

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -27,7 +27,7 @@ class TestCharm(unittest.TestCase):
         downstream_rel_id = self.harness.add_relation("metrics-endpoint", "prometheus-k8s")
 
         self.assertEqual(
-            {},
+            {'scrape_jobs': '[]'},
             self.harness.get_relation_data(downstream_rel_id, self.harness.charm.app.name),
         )
 
@@ -152,7 +152,7 @@ class TestCharm(unittest.TestCase):
             downstream_rel_id, self.harness.charm.app.name
         )
 
-        self.assertEqual([], list(relation_data.keys()))
+        self.assertEqual(['scrape_jobs'], list(relation_data.keys()))
         self.assertIsInstance(self.harness.model.unit.status, BlockedStatus)
 
     def test_charm_blocks_if_target_includes_path(self):
@@ -166,7 +166,7 @@ class TestCharm(unittest.TestCase):
             downstream_rel_id, self.harness.charm.app.name
         )
 
-        self.assertEqual([], list(relation_data.keys()))
+        self.assertEqual(['scrape_jobs'], list(relation_data.keys()))
         self.assertIsInstance(self.harness.model.unit.status, BlockedStatus)
 
     def test_charm_blocks_if_specified_port_invalid(self):
@@ -181,4 +181,4 @@ class TestCharm(unittest.TestCase):
         )
 
         self.assertIsInstance(self.harness.model.unit.status, BlockedStatus)
-        self.assertEqual({}, dict(relation_data))
+        self.assertEqual({'scrape_jobs': '[]'}, dict(relation_data))

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -27,7 +27,7 @@ class TestCharm(unittest.TestCase):
         downstream_rel_id = self.harness.add_relation("metrics-endpoint", "prometheus-k8s")
 
         self.assertEqual(
-            {'scrape_jobs': '[]'},
+            {"scrape_jobs": "[]"},
             self.harness.get_relation_data(downstream_rel_id, self.harness.charm.app.name),
         )
 
@@ -152,7 +152,7 @@ class TestCharm(unittest.TestCase):
             downstream_rel_id, self.harness.charm.app.name
         )
 
-        self.assertEqual(['scrape_jobs'], list(relation_data.keys()))
+        self.assertEqual(["scrape_jobs"], list(relation_data.keys()))
         self.assertIsInstance(self.harness.model.unit.status, BlockedStatus)
 
     def test_charm_blocks_if_target_includes_path(self):
@@ -166,7 +166,7 @@ class TestCharm(unittest.TestCase):
             downstream_rel_id, self.harness.charm.app.name
         )
 
-        self.assertEqual(['scrape_jobs'], list(relation_data.keys()))
+        self.assertEqual(["scrape_jobs"], list(relation_data.keys()))
         self.assertIsInstance(self.harness.model.unit.status, BlockedStatus)
 
     def test_charm_blocks_if_specified_port_invalid(self):
@@ -181,4 +181,4 @@ class TestCharm(unittest.TestCase):
         )
 
         self.assertIsInstance(self.harness.model.unit.status, BlockedStatus)
-        self.assertEqual({'scrape_jobs': '[]'}, dict(relation_data))
+        self.assertEqual({"scrape_jobs": "[]"}, dict(relation_data))


### PR DESCRIPTION
This PR fix #9.

Steps to check the bug is fixed:

1. Deploy Prometheus: `juju deploy prometheus-k8s --channel beta`
2. Build this charm: `charmcraft pack`
3. Deploy it: `juju deploy ./*.charm targets --channel=beta --config targets=127.0.0.1 --config labels=foo:bar,foo2:bar2`
4. Relate both charms: `juju add-relation prometheus-k8s targets`
5. Check etc/prometheus/prometheus.yml:
```bash
root@prometheus-k8s-0:/etc/prometheus# cat prometheus.yml
global:
  evaluation_interval: 1m
  scrape_interval: 1m
  scrape_timeout: 10s
rule_files:
- /etc/prometheus/rules/juju_*.rules
scrape_configs:
- honor_timestamps: true
  job_name: prometheus
  metrics_path: /metrics
  scheme: http
  scrape_interval: 5s
  scrape_timeout: 5s
  static_configs:
  - targets:
    - localhost:9090
- honor_labels: true
  job_name: juju_observability_fb7d3c3_targets_external_jobs
  static_configs:
  - labels:
      foo: bar
      foo2: bar2
    targets:
    - 127.0.0.1
```
6. Blank target: `juju config targets targets=`
7. Re-check etc/prometheus/prometheus.yml and verify scrape jobs are removed:
```bash
root@prometheus-k8s-0:/etc/prometheus# cat prometheus.yml
global:
  evaluation_interval: 1m
  scrape_interval: 1m
  scrape_timeout: 10s
rule_files:
- /etc/prometheus/rules/juju_*.rules
scrape_configs:
- honor_timestamps: true
  job_name: prometheus
  metrics_path: /metrics
  scheme: http
  scrape_interval: 5s
  scrape_timeout: 5s
  static_configs:
  - targets:
    - localhost:9090
``` 
