### PR TITLE
Fix scrape target URL in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ $ juju deploy prometheus-scrape-target-k8s
 $ juju relate prometheus-k8s prometheus-scrape-target-k8s
 
 # Setup http://192.168.5.2:7000 as an external target
-juju config prometheus-scrape-target targets="http://192.168.5.2:7000"
+juju config prometheus-scrape-target targets="192.168.5.2:7000"
 ```
 
 ## Relations

--- a/config.yaml
+++ b/config.yaml
@@ -5,7 +5,7 @@
 
 options:
   targets:
-    description: Comma separated list of external scrape targets.
+    description: Comma separated list of external scrape targets, e.g., "192.168.5.2:7000,192.168.5.3:7000"; do not add the protocol!
     type: string
   labels:
     description: Comma separated list of label:value pairs.


### PR DESCRIPTION
Scrape target urls must not contain the protocol prefix but
our readme shows an example using this prefix. This commit
fixes the issue.