### PR TITLE
Add config options for tls, basic_auth

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -17,3 +17,14 @@ options:
   metrics_path:
     description: Metrics path for external jobs.
     type: string
+  scheme:
+    description: dfdf
+    type: string
+  basic_auth:
+    # TODO: this should be removed after juju secrets are available
+    description: username:password
+    type: string
+  tls_config_ca_file:
+    # TODO: this should be removed after juju secrets are available
+    description: dfdf
+    type: string

--- a/config.yaml
+++ b/config.yaml
@@ -28,3 +28,6 @@ options:
     # TODO: this should be removed after juju secrets are available
     description: dfdf
     type: string
+  tls_config_insecure_skip_verify:
+    description: dfdf
+    type: boolean

--- a/config.yaml
+++ b/config.yaml
@@ -18,16 +18,18 @@ options:
     description: Metrics path for external jobs.
     type: string
   scheme:
-    description: dfdf
+    description: Configures the protocol scheme prometheus uses for requests.
     type: string
   basic_auth:
     # TODO: this should be removed after juju secrets are available
-    description: username:password
+    description: >
+      Sets the Authorization header prometheus uses on every scrape request.
+      The expected format is username:password.
     type: string
   tls_config_ca_file:
     # TODO: this should be removed after juju secrets are available
-    description: dfdf
+    description: CA certificate to validate API server certificate with.
     type: string
   tls_config_insecure_skip_verify:
-    description: dfdf
+    description: Disable validation of the server certificate.
     type: boolean

--- a/src/charm.py
+++ b/src/charm.py
@@ -102,7 +102,10 @@ class PrometheusScrapeTargetCharm(CharmBase):
             if ca_file := self.model.config.get("tls_config_ca_file"):
                 tls_config.update({"ca_file": ca_file})
             if insecure_skip_verify := self.model.config.get("tls_config_insecure_skip_verify"):
-                tls_config.update({"ca_file": insecure_skip_verify})
+                # Need to convert bool to lowercase str
+                tls_config.update(
+                    {"insecure_skip_verify": "true" if insecure_skip_verify else "false"}
+                )
             if tls_config:
                 job.update({"tls_config": tls_config})
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -103,9 +103,7 @@ class PrometheusScrapeTargetCharm(CharmBase):
                 tls_config.update({"ca_file": ca_file})
             if insecure_skip_verify := self.model.config.get("tls_config_insecure_skip_verify"):
                 # Need to convert bool to lowercase str
-                tls_config.update(
-                    {"insecure_skip_verify": "true" if insecure_skip_verify else "false"}
-                )
+                tls_config.update({"insecure_skip_verify": insecure_skip_verify})
             if tls_config:
                 job.update({"tls_config": tls_config})
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -80,7 +80,7 @@ class PrometheusScrapeTargetCharm(CharmBase):
         else:
             self.unit.status = BlockedStatus("No targets specified")
 
-    def _scrape_jobs(self) -> list:
+    def _scrape_jobs(self) -> list:  # noqa: C901
         if targets := self._targets():
             static_config = {"targets": targets}
             if labels := self._labels():
@@ -98,8 +98,13 @@ class PrometheusScrapeTargetCharm(CharmBase):
                 if value := self.model.config.get(option):
                     job.update({option: value})
 
-            if tls_config_ca_file := self.model.config.get("tls_config_ca_file"):
-                job.update({"tls_config": {"ca_file": tls_config_ca_file}})
+            tls_config = {}
+            if ca_file := self.model.config.get("tls_config_ca_file"):
+                tls_config.update({"ca_file": ca_file})
+            if insecure_skip_verify := self.model.config.get("tls_config_insecure_skip_verify"):
+                tls_config.update({"ca_file": insecure_skip_verify})
+            if tls_config:
+                job.update({"tls_config": tls_config})
 
             if basic_auth := self.model.config.get("basic_auth"):
                 try:

--- a/src/charm.py
+++ b/src/charm.py
@@ -91,10 +91,25 @@ class PrometheusScrapeTargetCharm(CharmBase):
                 "static_configs": [static_config],
             }
 
-            if metrics_path := self.model.config.get("metrics_path"):
-                # prometheus has a its own built-in default for metrics_path:
-                # [ metrics_path: <path> | default = /metrics ]
-                job.update(metrics_path=metrics_path)
+            for option in (
+                "metrics_path",  # prom's built-in default: [ metrics_path: <path> | default = /metrics ]
+                "scheme",
+            ):
+                if value := self.model.config.get(option):
+                    job.update({option: value})
+
+            if tls_config_ca_file := self.model.config.get("tls_config_ca_file"):
+                job.update({"tls_config": {"ca_file": tls_config_ca_file}})
+
+            if basic_auth := self.model.config.get("basic_auth"):
+                try:
+                    username, password = basic_auth.split(":")
+                except ValueError:
+                    self.unit.status = BlockedStatus(
+                        "Invalid basic_auth config option; use `user:password` format"
+                    )
+                else:
+                    job.update({"basic_auth": {"username": username, "password": password}})
 
             return [job]
 


### PR DESCRIPTION
## Issue
https://github.com/canonical/prometheus-k8s-operator/issues/347


## Solution
Add config options for tls, basic_auth


## Context
NTA


## Testing Instructions
- Manually deploy and relate this and [prom](https://github.com/canonical/prometheus-k8s-operator/pull/351).


## Release Notes
Add config options for tls, basic_auth.
