### PR TITLE
add params support

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -20,6 +20,10 @@ options:
   scheme:
     description: Configures the protocol scheme prometheus uses for requests.
     type: string
+  params:
+    description: >
+      Configures optional HTTP URL parameters as a key-value collection.
+    type: string
   basic_auth:
     # TODO: this should be removed after juju secrets are available
     description: >

--- a/src/charm.py
+++ b/src/charm.py
@@ -7,6 +7,7 @@
 """Prometheus Scrape Target Charm."""
 
 import json
+import yaml
 import logging
 from urllib.parse import urlparse
 
@@ -108,6 +109,10 @@ class PrometheusScrapeTargetCharm(CharmBase):
             ):
                 if value := self.model.config.get(option):
                     job.update({option: value})
+
+            if params := self.model.config.get("params"):
+                val = yaml.safe_load(params)
+                job.update({"params": val})
 
             tls_config = {}
             if ca_file := self.model.config.get("tls_config_ca_file"):


### PR DESCRIPTION
## Issue
Federated endpoints expect you to provide a query filter. This is currently not possible with the scrape target charm.


## Solution
<!-- A summary of the solution addressing the above issue -->
Add params as a config option

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->
Needed by Bootstack

## Testing Instructions
<!-- What steps need to be taken to test this PR? -->
1. Deploy charm
2. Set a scrape target
3. Add params from a file
4. Check the prometheus unit to make sure the params are included in the scrape job.

## Release Notes
<!-- A digestable summary of the change in this PR -->
Add support for external federated endpoints.