### PR TITLE
Add support for client certificates

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -20,6 +20,10 @@ options:
   scheme:
     description: Configures the protocol scheme prometheus uses for requests.
     type: string
+  params:
+    description: >
+      Configures optional HTTP URL parameters as a key-value collection.
+    type: string
   basic_auth:
     # TODO: this should be removed after juju secrets are available
     description: >

--- a/config.yaml
+++ b/config.yaml
@@ -5,35 +5,54 @@
 
 options:
   targets:
-    description: Comma separated list of external scrape targets, e.g., "192.168.5.2:7000,192.168.5.3:7000"; do not add the protocol!
     type: string
+    description: >
+      Comma separated list of external scrape targets, e.g., "192.168.5.2:7000,192.168.5.3:7000"; 
+      do not add the protocol!
   labels:
-    description: Comma separated list of label:value pairs.
     type: string
+    description: >
+      Comma separated list of label:value pairs.
   job_name:
-    description: Name of external scrape configuration jobs.
     type: string
     default: "external_jobs"
+    description: >
+      Name of external scrape configuration jobs.
   metrics_path:
-    description: Metrics path for external jobs.
     type: string
+    description: >
+      Metrics path for external jobs.
   scheme:
-    description: Configures the protocol scheme prometheus uses for requests.
     type: string
+    description: >
+      Configures the protocol scheme prometheus uses for requests.
   params:
     description: >
       Configures optional HTTP URL parameters as a key-value collection.
     type: string
   basic_auth:
-    # TODO: this should be removed after juju secrets are available
+    type: string
     description: >
       Sets the Authorization header prometheus uses on every scrape request.
       The expected format is username:password.
+  tls_config_key_file:
     type: string
+    description: >
+      Certificate key to request API server access with.
+  tls_config_cert_file:
+    type: string
+    description: >
+      Certificate to request API server access with.
+  tls_config_server_name:
+    type: string
+    description: >
+      Server name to access the API server with. Only relevant if the cert 
+      is not including it's name in the SANs.
   tls_config_ca_file:
-    # TODO: this should be removed after juju secrets are available
-    description: CA certificate to validate API server certificate with.
     type: string
+    description: >
+      CA certificate to validate API server certificate with.
   tls_config_insecure_skip_verify:
-    description: Disable validation of the server certificate.
     type: boolean
+    description: >
+      Disable validation of the server certificate.

--- a/examples/params.yaml
+++ b/examples/params.yaml
@@ -1,0 +1,3 @@
+'match[]':
+  - '{job="prometheus"}'
+  - '{__name__=~"job:.*"}'

--- a/src/charm.py
+++ b/src/charm.py
@@ -115,11 +115,19 @@ class PrometheusScrapeTargetCharm(CharmBase):
                 job.update({"params": val})
 
             tls_config = {}
+            
+            if cert_file := self.model.config.get("tls_config_cert_file"):
+                tls_config.update({"cert_file": cert_file})
+            if key_file := self.model.config.get("tls_config_key_file"):
+                tls_config.update({"key_file": key_file})
+            if server_name := self.model.config.get("tls_config_server_name"):
+                tls_config.update({"server_name": server_name})
             if ca_file := self.model.config.get("tls_config_ca_file"):
                 tls_config.update({"ca_file": ca_file})
             if insecure_skip_verify := self.model.config.get("tls_config_insecure_skip_verify"):
                 # Need to convert bool to lowercase str
                 tls_config.update({"insecure_skip_verify": insecure_skip_verify})
+            
             if tls_config:
                 job.update({"tls_config": tls_config})
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -115,7 +115,7 @@ class PrometheusScrapeTargetCharm(CharmBase):
                 job.update({"params": val})
 
             tls_config = {}
-            
+
             if cert_file := self.model.config.get("tls_config_cert_file"):
                 tls_config.update({"cert_file": cert_file})
             if key_file := self.model.config.get("tls_config_key_file"):
@@ -127,7 +127,7 @@ class PrometheusScrapeTargetCharm(CharmBase):
             if insecure_skip_verify := self.model.config.get("tls_config_insecure_skip_verify"):
                 # Need to convert bool to lowercase str
                 tls_config.update({"insecure_skip_verify": insecure_skip_verify})
-            
+
             if tls_config:
                 job.update({"tls_config": tls_config})
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -7,10 +7,10 @@
 """Prometheus Scrape Target Charm."""
 
 import json
-import yaml
 import logging
 from urllib.parse import urlparse
 
+import yaml
 from ops.charm import CharmBase
 from ops.main import main
 from ops.model import ActiveStatus, BlockedStatus, WaitingStatus

--- a/src/charm.py
+++ b/src/charm.py
@@ -7,6 +7,7 @@
 """Prometheus Scrape Target Charm."""
 
 import json
+import yaml
 import logging
 from urllib.parse import urlparse
 
@@ -108,6 +109,10 @@ class PrometheusScrapeTargetCharm(CharmBase):
             ):
                 if value := self.model.config.get(option):
                     job.update({option: value})
+
+            if params := self.model.config.get("params"):
+                val = yaml.safe_load(params)
+                job.update({"params": val})
 
             tls_config = {}
             if ca_file := self.model.config.get("tls_config_ca_file"):


### PR DESCRIPTION
resolves #30 
## Issue
<!-- What issue is this PR trying to solve? -->
Can't add a client cert or key

## Solution
<!-- A summary of the solution addressing the above issue -->
For integration with some services, for instance LXD, we need to provide a way to add a client cert and key file through the scrape-target charm

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->
1. deploy our charm
2. relate it to prometheus
3. add a cert file
4. add a key file

## Release Notes
<!-- A digestable summary of the change in this PR -->
Surface config options for client tls #29 