### PR TITLE
fix: tell type checkers that the config options are strings

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -8,6 +8,7 @@
 
 import json
 import logging
+import typing
 from urllib.parse import urlparse
 
 import yaml
@@ -111,19 +112,19 @@ class PrometheusScrapeTargetCharm(CharmBase):
                     job.update({option: value})
 
             if params := self.model.config.get("params"):
-                val = yaml.safe_load(params)
+                val = yaml.safe_load(typing.cast(str, params))
                 job.update({"params": val})
 
             tls_config = {}
 
             if cert_file := self.model.config.get("tls_config_cert_file"):
-                tls_config.update({"cert_file": cert_file})
+                tls_config.update({"cert_file": typing.cast(str, cert_file)})
             if key_file := self.model.config.get("tls_config_key_file"):
-                tls_config.update({"key_file": key_file})
+                tls_config.update({"key_file": typing.cast(str, key_file)})
             if server_name := self.model.config.get("tls_config_server_name"):
-                tls_config.update({"server_name": server_name})
+                tls_config.update({"server_name": typing.cast(str, server_name)})
             if ca_file := self.model.config.get("tls_config_ca_file"):
-                tls_config.update({"ca_file": ca_file})
+                tls_config.update({"ca_file": typing.cast(str, ca_file)})
             if insecure_skip_verify := self.model.config.get("tls_config_insecure_skip_verify"):
                 # Need to convert bool to lowercase str
                 tls_config.update({"insecure_skip_verify": insecure_skip_verify})
@@ -133,7 +134,7 @@ class PrometheusScrapeTargetCharm(CharmBase):
 
             if basic_auth := self.model.config.get("basic_auth"):
                 try:
-                    username, password = basic_auth.split(":")
+                    username, password = typing.cast(str, basic_auth).split(":")
                 except ValueError:
                     self.unit.status = BlockedStatus(
                         "Invalid basic_auth config option; use `user:password` format"
@@ -152,6 +153,7 @@ class PrometheusScrapeTargetCharm(CharmBase):
 
         targets = []
         invalid_targets = []
+        unvalidated_scrape_targets = typing.cast(str, unvalidated_scrape_targets)
         for config_target in unvalidated_scrape_targets.split(","):
             if valid_address := _validated_address(config_target):
                 targets.append(valid_address)
@@ -172,6 +174,7 @@ class PrometheusScrapeTargetCharm(CharmBase):
 
         labels = {}
         invalid_labels = []
+        all_labels = typing.cast(str, all_labels)
         for label in all_labels.split(","):
             try:
                 key, value = label.split(":")


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->

ops<=2.12 wrongly has `self.config[x]` typed as `str`, when actually it could be an int, float, bool, or str, depending on the config type. We're fixing this in [ops:#1183](https://github.com/canonical/operator/pull/1183), but that will break static checking that currently assumes that the config is a str (because ops doesn't validate the schema, so all options will be bool|int|float|str).

## Solution
<!-- A summary of the solution addressing the above issue -->

This PR adds a `typing.cast` call where the config values are loaded and used where the type should be str.

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->

N/A

## Testing Instructions
<!-- What steps need to be taken to test this PR? -->

Run `tox -e static-charm` with / without this change, with ops 2.12 and ops 2.13 (or the PR linked above if before that release).

## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->

N/A